### PR TITLE
PHP8.4 Implicitly marking parameter <x> as nullable is deprecated

### DIFF
--- a/src/JsonRPC/Client.php
+++ b/src/JsonRPC/Client.php
@@ -51,11 +51,11 @@ class Client
     private $httpClient;
 
     /**
-     * @param  string      $url               Server URL
-     * @param  bool        $returnException   Return exceptions
-     * @param  HttpClient  $httpClient        HTTP client object
+     * @param string $url Server URL
+     * @param bool $returnException Return exceptions
+     * @param HttpClient|null $httpClient HTTP client object
      */
-    public function __construct($url = '', $returnException = false, HttpClient $httpClient = null)
+    public function __construct($url = '', $returnException = false, ?HttpClient $httpClient = null)
     {
         $this->httpClient = $httpClient ?: new HttpClient($url);
         $this->returnException = $returnException;

--- a/src/JsonRPC/Exception/ResponseException.php
+++ b/src/JsonRPC/Exception/ResponseException.php
@@ -21,12 +21,12 @@ class ResponseException extends RpcCallFailedException
     protected $data;
 
     /**
-     * @param string    $message  [optional] The Exception message to throw.
-     * @param int       $code     [optional] The Exception code.
-     * @param Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
-     * @param mixed     $data     [optional] A value that contains additional information about the error.
+     * @param string $message [optional] The Exception message to throw.
+     * @param int $code [optional] The Exception code.
+     * @param Exception|null $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
+     * @param mixed $data [optional] A value that contains additional information about the error.
      */
-    public function __construct($message = '', $code = 0, Exception $previous = null, $data = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null, $data = null)
     {
         parent::__construct($message, $code, $previous);
         $this->setData($data);

--- a/src/JsonRPC/Server.php
+++ b/src/JsonRPC/Server.php
@@ -104,22 +104,22 @@ class Server
     protected $batchRequestParser;
 
     /**
-     * @param  string              $request
-     * @param  array               $server
-     * @param  ResponseBuilder     $responseBuilder
-     * @param  RequestParser       $requestParser
-     * @param  BatchRequestParser  $batchRequestParser
-     * @param  ProcedureHandler    $procedureHandler
-     * @param  MiddlewareHandler   $middlewareHandler
+     * @param string $request
+     * @param array $server
+     * @param ResponseBuilder|null $responseBuilder
+     * @param RequestParser|null $requestParser
+     * @param BatchRequestParser|null $batchRequestParser
+     * @param ProcedureHandler|null $procedureHandler
+     * @param MiddlewareHandler|null $middlewareHandler
      */
     public function __construct(
         $request = '',
         array $server = [],
-        ResponseBuilder $responseBuilder = null,
-        RequestParser $requestParser = null,
-        BatchRequestParser $batchRequestParser = null,
-        ProcedureHandler $procedureHandler = null,
-        MiddlewareHandler $middlewareHandler = null
+        ?ResponseBuilder $responseBuilder = null,
+        ?RequestParser $requestParser = null,
+        ?BatchRequestParser $batchRequestParser = null,
+        ?ProcedureHandler $procedureHandler = null,
+        ?MiddlewareHandler $middlewareHandler = null
     ) {
         if ($request !== '') {
             $this->payload = json_decode($request, true);
@@ -149,7 +149,7 @@ class Server
             $value = $this->getServerVariable($header);
 
             if (! empty($value)) {
-                list($this->username, $this->password) = explode(':', base64_decode($value));
+                [$this->username, $this->password] = explode(':', base64_decode($value));
             }
         }
 


### PR DESCRIPTION
Fix for: https://github.com/matasarei/json-rpc/issues