### PR TITLE
Function curl_close() is deprecated since 8.5, as it has no effect si…

### DIFF
--- a/src/JsonRPC/HttpClient.php
+++ b/src/JsonRPC/HttpClient.php
@@ -310,7 +310,6 @@ class HttpClient
             }
 
             $response = curl_exec($ch);
-            curl_close($ch);
 
             if (false === $response) {
                 throw new ConnectionFailureException('Unable to establish a connection');


### PR DESCRIPTION
…nce PHP 8.0