### PR TITLE
Function curl_close() is deprecated since 8.5, as it has no effect si…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.0",
     "ext-json": "*"
   },
   "autoload": {

--- a/src/JsonRPC/HttpClient.php
+++ b/src/JsonRPC/HttpClient.php
@@ -311,11 +311,6 @@ class HttpClient
 
             $response = curl_exec($ch);
 
-            if (PHP_VERSION_ID < 80000) {
-                // Before PHP 8.0: cURL handle is a resource and should be explicitly closed
-                curl_close($ch);
-            }
-
             if (false === $response) {
                 throw new ConnectionFailureException('Unable to establish a connection');
             }

--- a/src/JsonRPC/HttpClient.php
+++ b/src/JsonRPC/HttpClient.php
@@ -311,6 +311,11 @@ class HttpClient
 
             $response = curl_exec($ch);
 
+            if (PHP_VERSION_ID < 80000) {
+                // Before PHP 8.0: cURL handle is a resource and should be explicitly closed
+                curl_close($ch);
+            }
+
             if (false === $response) {
                 throw new ConnectionFailureException('Unable to establish a connection');
             }

--- a/src/JsonRPC/HttpClient.php
+++ b/src/JsonRPC/HttpClient.php
@@ -310,7 +310,6 @@ class HttpClient
             }
 
             $response = curl_exec($ch);
-            curl_close($ch);
 
             if (false === $response) {
                 throw new ConnectionFailureException('Unable to establish a connection');

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -52,11 +52,6 @@ function curl_exec($ch)
     return HttpClientTest::$functions->curl_exec($ch);
 }
 
-function curl_close($ch)
-{
-    HttpClientTest::$functions->curl_close($ch);
-}
-
 function curl_getinfo($ch, $option)
 {
     HttpClientTest::$functions->curl_getinfo($ch, $option);
@@ -72,7 +67,7 @@ class HttpClientTest extends TestCase
             ->getMockBuilder('stdClass')
             ->setMethods([
                 'extension_loaded', 'fopen', 'stream_context_create', 'curl_getinfo',
-                'curl_init', 'curl_setopt_array', 'curl_setopt', 'curl_exec', 'curl_close'
+                'curl_init', 'curl_setopt_array', 'curl_setopt', 'curl_exec',
             ])
             ->getMock();
     }
@@ -215,11 +210,6 @@ class HttpClientTest extends TestCase
             ->method('curl_exec')
             ->with('curl')
             ->will($this->returnValue(false));
-
-        self::$functions
-            ->expects(static::exactly(1))
-            ->method('curl_close')
-            ->with('curl');
 
         $httpClient = new HttpClient('url');
         $httpClient


### PR DESCRIPTION
…nce PHP 8.0