### PR TITLE
Upgrade to PHP 8.2 and modernization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
       "name": "Frédéric Guillot"
     }
   ],
-  "require": {
-    "php": ">=8.0",
-    "ext-json": "*"
-  },
+    "require": {
+        "php": ">=8.2",
+        "ext-json": "*"
+    },
   "autoload": {
     "psr-0": {
       "JsonRPC": "src/"
@@ -20,6 +20,12 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6",
-    "squizlabs/php_codesniffer": "^3.9"
+    "squizlabs/php_codesniffer": "^3.9",
+    "doctrine/instantiator": "^2.0"
+  },
+  "config": {
+    "platform": {
+      "php": "8.2.0"
+    }
   }
 }

--- a/src/JsonRPC/HttpClient.php
+++ b/src/JsonRPC/HttpClient.php
@@ -278,7 +278,7 @@ class HttpClient
             $ch = curl_init();
             $headers = [];
             $options = [
-                CURLOPT_URL => trim($this->url),
+                CURLOPT_URL => trim((string)$this->url),
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_CONNECTTIMEOUT => $this->timeout,
                 CURLOPT_MAXREDIRS => 2,
@@ -317,7 +317,7 @@ class HttpClient
 
             $response = json_decode($response, true);
         } else {
-            $stream = fopen(trim($this->url), 'r', false, $this->buildContext($payload, $requestHeaders));
+            $stream = fopen(trim((string)$this->url), 'r', false, $this->buildContext($payload, $requestHeaders));
 
             if (!is_resource($stream)) {
                 throw new ConnectionFailureException('Unable to establish a connection');

--- a/src/JsonRPC/ProcedureHandler.php
+++ b/src/JsonRPC/ProcedureHandler.php
@@ -272,7 +272,7 @@ class ProcedureHandler
      */
     public function isPositionalArguments(array $request_params)
     {
-        return array_keys($request_params) === range(0, count($request_params) - 1);
+        return ! empty($request_params) && array_is_list($request_params);
     }
 
     /**

--- a/src/JsonRPC/Request/BatchRequestParser.php
+++ b/src/JsonRPC/Request/BatchRequestParser.php
@@ -50,6 +50,6 @@ class BatchRequestParser extends RequestParser
      */
     public static function isBatchRequest(array $payload)
     {
-        return array_keys($payload) === range(0, count($payload) - 1);
+        return ! empty($payload) && array_is_list($payload);
     }
 }

--- a/src/JsonRPC/Request/RequestBuilder.php
+++ b/src/JsonRPC/Request/RequestBuilder.php
@@ -110,7 +110,7 @@ class RequestBuilder
         $payload = array_merge_recursive($this->reqattrs, [
             'jsonrpc' => '2.0',
             'method' => $this->procedure,
-            'id' => $this->id ?: mt_rand(),
+            'id' => $this->id ?: (new \Random\Randomizer())->getInt(1, 1000000),
         ]);
 
         if (! empty($this->params)) {

--- a/src/JsonRPC/Response/ResponseParser.php
+++ b/src/JsonRPC/Response/ResponseParser.php
@@ -146,6 +146,6 @@ class ResponseParser
      */
     private function isBatchResponse()
     {
-        return array_keys($this->payload) === range(0, count($this->payload) - 1);
+        return ! empty($this->payload) && array_is_list($this->payload);
     }
 }

--- a/src/JsonRPC/Validator/HostValidator.php
+++ b/src/JsonRPC/Validator/HostValidator.php
@@ -42,10 +42,10 @@ class HostValidator
      */
     public static function ipMatch($remoteAddress, $host)
     {
-        $host = trim($host);
+        $host = trim((string)$host);
         if (strpos($host, '/') !== false) {
             list($network, $mask) = explode('/', $host);
-            if (self::netMatch($remoteAddress, $network, $mask)) {
+            if (self::netMatch((string)$remoteAddress, (string)$network, (string)$mask)) {
                 return true;
             }
         }
@@ -68,7 +68,7 @@ class HostValidator
      */
     public static function netMatch($clientIp, $networkIp, $mask)
     {
-        $mask1 = 32 - $mask;
-        return ((ip2long($clientIp) >> $mask1) == (ip2long($networkIp) >> $mask1));
+        $mask1 = 32 - (int)$mask;
+        return ((ip2long((string)$clientIp) >> $mask1) == (ip2long((string)$networkIp) >> $mask1));
     }
 }

--- a/src/JsonRPC/Validator/UserValidator.php
+++ b/src/JsonRPC/Validator/UserValidator.php
@@ -14,6 +14,7 @@ class UserValidator
 {
     public static function validate(array $users, $username, $password)
     {
+        $username = (string)$username;
         if (! empty($users) && (! isset($users[$username]) || $users[$username] !== $password)) {
             throw new AuthenticationFailureException('Access not allowed');
         }

--- a/tests/Response/HeaderMockTest.php
+++ b/tests/Response/HeaderMockTest.php
@@ -19,7 +19,7 @@ abstract class HeaderMockTest extends TestCase
     {
         self::$functions = $this
             ->getMockBuilder('stdClass')
-            ->setMethods(['header'])
+            ->addMethods(['header'])
             ->getMock();
     }
 }


### PR DESCRIPTION
- Update minimum PHP version requirement to 8.2 in composer.json
- Replace mt_rand() with \Random\Randomizer in RequestBuilder
- Use array_is_list() for batch and positional argument detection
- Add explicit string casting to avoid PHP 8.1+ null-to-string deprecations
- Fix PHPUnit setMethods() deprecation in tests
- Pin doctrine/instantiator to 2.0.0 to maintain PHP 8.2 compatibility